### PR TITLE
Caught expected failures.

### DIFF
--- a/fuzzers.py
+++ b/fuzzers.py
@@ -1,6 +1,7 @@
 from django.core.exceptions import (
     ValidationError,
     SuspiciousFileOperation,
+    SuspiciousOperation,
 )
 
 from django.utils import text
@@ -142,12 +143,18 @@ def test_strip_spaces_between_tags(inp):
 def test_strip_tags(inp):
     try:
         strip_tags(inp)
+    except SuspiciousOperation:
+        pass
     except NotImplementedError:  # TODO: this should be fixed
         pass
 
 
 def test_urlize(inp):
-    urlize(inp)
+    try:
+        urlize(inp)
+    except ValueError:
+        # >4300 digits
+        pass
 
 
 def test_smart_split(inp):


### PR DESCRIPTION
For `strip_tags()` see https://github.com/django/django/commit/49ff1042aa66bb25eda87e9a8ef82f3b0ad4eeba.
For `urlize()` see https://docs.python.org/3/library/stdtypes.html#int-max-str-digits.