### PR TITLE
Caught further expected failures.

### DIFF
--- a/fuzzers.py
+++ b/fuzzers.py
@@ -162,7 +162,11 @@ def test_smart_split(inp):
 
 
 def test_Truncator(inp):
-    text.Truncator(inp).words(8, "...", html=True)
+    try:
+        text.Truncator(inp).words(8, "...", html=True)
+    except ValueError:
+        # >4300 digits
+        pass
 
 
 def test_wrap(inp):


### PR DESCRIPTION
Follow-up to #5. One more failure came through on the google-hosted dashboard, involving the same failure case with a string of more than 4300 ints.